### PR TITLE
Prestack all image observations for faster data loading

### DIFF
--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -52,6 +52,7 @@ class Dataset(FrozenDict):
         super().__init__(*args, **kwargs)
         self.size = get_size(self._dict)
         self.frame_stack = None  # Number of frames to stack; set outside the class.
+        self._prestacked = False
         self.p_aug = None  # Image augmentation probability; set outside the class.
         self.return_next_actions = False  # Whether to additionally return next actions; set outside the class.
 
@@ -62,27 +63,42 @@ class Dataset(FrozenDict):
     def get_random_idxs(self, num_idxs):
         """Return `num_idxs` random indices."""
         return np.random.randint(self.size, size=num_idxs)
+    
+    def _prestack_frames(self):
+        """Preprocess for frame stacking -- avoid much delay in batch loading."""
+        # Stack frames.
+        idxs = np.arange(self.size)
+        initial_state_idxs = self.initial_locs[np.searchsorted(self.initial_locs, idxs, side='right') - 1]
+        obs = []  # Will be [ob[t - frame_stack + 1], ..., ob[t]].
+        next_obs = []  # Will be [ob[t - frame_stack + 2], ..., ob[t], next_ob[t]].
+        for i in reversed(range(self.frame_stack)):
+            # Use the initial state if the index is out of bounds.
+            cur_idxs = np.maximum(idxs - i, initial_state_idxs)
+            obs.append(jax.tree_util.tree_map(lambda arr: arr[cur_idxs], self['observations']))
+            if i != self.frame_stack - 1:
+                next_obs.append(jax.tree_util.tree_map(lambda arr: arr[cur_idxs], self['observations']))
+        next_obs.append(jax.tree_util.tree_map(lambda arr: arr[idxs], self['next_observations']))
+
+        obs = jax.tree_util.tree_map(lambda *args: np.concatenate(args, axis=-1), *obs)
+        next_obs = jax.tree_util.tree_map(lambda *args: np.concatenate(args, axis=-1), *next_obs)
+        # overwrite unstacked frame version of self._dict
+        obs.setflags(write=False)
+        next_obs.setflags(write=False)
+        self._dict['observations'] = obs
+        self._dict['next_observations'] = next_obs
+        # don't need to prestack once we've already prestacked...
+        self._prestacked = True
+        return
 
     def sample(self, batch_size: int, idxs=None):
         """Sample a batch of transitions."""
+        # prestack frames for faster batch sampling
+        if (self.frame_stack is not None) and (not self._prestacked):
+            self._prestack_frames()
+        # get indices to include in this batch
         if idxs is None:
             idxs = self.get_random_idxs(batch_size)
         batch = self.get_subset(idxs)
-        if self.frame_stack is not None:
-            # Stack frames.
-            initial_state_idxs = self.initial_locs[np.searchsorted(self.initial_locs, idxs, side='right') - 1]
-            obs = []  # Will be [ob[t - frame_stack + 1], ..., ob[t]].
-            next_obs = []  # Will be [ob[t - frame_stack + 2], ..., ob[t], next_ob[t]].
-            for i in reversed(range(self.frame_stack)):
-                # Use the initial state if the index is out of bounds.
-                cur_idxs = np.maximum(idxs - i, initial_state_idxs)
-                obs.append(jax.tree_util.tree_map(lambda arr: arr[cur_idxs], self['observations']))
-                if i != self.frame_stack - 1:
-                    next_obs.append(jax.tree_util.tree_map(lambda arr: arr[cur_idxs], self['observations']))
-            next_obs.append(jax.tree_util.tree_map(lambda arr: arr[idxs], self['next_observations']))
-
-            batch['observations'] = jax.tree_util.tree_map(lambda *args: np.concatenate(args, axis=-1), *obs)
-            batch['next_observations'] = jax.tree_util.tree_map(lambda *args: np.concatenate(args, axis=-1), *next_obs)
         if self.p_aug is not None:
             # Apply random-crop image augmentation.
             if np.random.rand() < self.p_aug:


### PR DESCRIPTION
Change dataloader to prestack all image observations when the first batch is sampled. This avoids the need for "online" stacking during training, and provides 2.5x-3x speedup with the default model size. It should also be possible to get another ~20% or so gain by reworking how random crops are done.